### PR TITLE
Remove default margin and padding from all round buttons

### DIFF
--- a/When/ClientApp/src/components/SubmitButton.module.css
+++ b/When/ClientApp/src/components/SubmitButton.module.css
@@ -1,4 +1,6 @@
 .submitButton {
+	margin: 0;
+	padding: 0;
 	min-width: 60px;
 	width: 60px;
 	height: 60px;

--- a/When/ClientApp/src/components/ToggleButton.module.css
+++ b/When/ClientApp/src/components/ToggleButton.module.css
@@ -1,4 +1,6 @@
 .toggleButton {
+	margin: 0;
+	padding: 0;
 	min-width: 60px;
 	height: 60px;
 	border-radius: 30px;


### PR DESCRIPTION
Closes #3 

Finally should fix all misplaced icons in round buttons by removing default margin and padding on mobile.