### PR TITLE
Add dotnet-tools manifest with dotnet-ef for DB migrations on Heroku

### DIFF
--- a/When/.config/dotnet-tools.json
+++ b/When/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "3.1.8",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Ran

- `dotnet new tool-manifest` to add a `dotnet-tools.json`
- `dotnet tool install dotnet-ef` to (hopefully) have EF CLI tools on the Heroku server