### PR TITLE
Replaced red crossed button with grey circle

### DIFF
--- a/When/ClientApp/src/components/DateGrid.module.css
+++ b/When/ClientApp/src/components/DateGrid.module.css
@@ -75,7 +75,7 @@
 	margin-right: 16px;
 }
 
-@media (max-width: 740px) {
+@media (max-width: 768px) {
 	.dateGrid {
 		overflow: none;
 		align-items: initial;

--- a/When/ClientApp/src/components/NameCircle.module.css
+++ b/When/ClientApp/src/components/NameCircle.module.css
@@ -21,7 +21,7 @@
 	background-color: #ef9c00;
 }
 
-@media (max-width: 740px) {
+@media (max-width: 768px) {
 	.stackedCircle {
 		margin-top: 0;
 		margin-left: -20px;

--- a/When/ClientApp/src/components/ToggleButton.module.css
+++ b/When/ClientApp/src/components/ToggleButton.module.css
@@ -29,7 +29,7 @@
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
 }
 
-@media (max-width: 740px) {
+@media (max-width: 768px) {
 	.toggleButton {
 		margin-bottom: 0;
 		margin-right: 16px;

--- a/When/ClientApp/src/components/ToggleButton.module.css
+++ b/When/ClientApp/src/components/ToggleButton.module.css
@@ -18,7 +18,15 @@
 }
 
 .toggleButton.no {
-	background-color: #ef0000;
+	border: 2px solid #afafaf;
+	background: none;
+	box-shadow: none;
+}
+
+.toggleButton.no:hover {
+	border: none;
+	background-color: #129f00;
+	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
 }
 
 @media (max-width: 740px) {

--- a/When/ClientApp/src/components/ToggleButton.tsx
+++ b/When/ClientApp/src/components/ToggleButton.tsx
@@ -30,7 +30,7 @@ export const ToggleButton = (props: {
 			}}
 		>
 			<img
-				src={buttonState === SelectionState.No ? cross : checkmark}
+				src={checkmark}
 				alt={SelectionState[buttonState]}
 			/>
 		</button>

--- a/When/ClientApp/src/pages/Home.module.css
+++ b/When/ClientApp/src/pages/Home.module.css
@@ -35,7 +35,7 @@
 	margin: 0 0 0 32px;
 }
 
-@media (max-width: 740px) {
+@media (max-width: 768px) {
 	.hero {
 		display: none;
 	}

--- a/When/ClientApp/src/pages/Poll.module.css
+++ b/When/ClientApp/src/pages/Poll.module.css
@@ -18,7 +18,7 @@
 	font-size: 28px;
 }
 
-@media (max-width: 740px) {
+@media (max-width: 768px) {
 	.resultsAndSubmit {
 		align-items: initial;
 		flex-direction: column;


### PR DESCRIPTION
Replaced red crossed button with grey circle that turns into a checkmark when hovered. 

That should make it more clear that the user can select a date as he can now place checkmarks instead of just clicking through a button that is not recognizable as such. 

Additionally aligned media queries with bootstrap breakpoints