### PR TITLE
Add loading spinners to actions with API-calls

### DIFF
--- a/When/ClientApp/package-lock.json
+++ b/When/ClientApp/package-lock.json
@@ -1161,6 +1161,94 @@
 			"resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
 			"integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
 		},
+		"@emotion/cache": {
+			"version": "10.0.29",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+			"requires": {
+				"@emotion/sheet": "0.9.4",
+				"@emotion/stylis": "0.8.5",
+				"@emotion/utils": "0.11.3",
+				"@emotion/weak-memoize": "0.2.5"
+			}
+		},
+		"@emotion/core": {
+			"version": "10.0.35",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.35.tgz",
+			"integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@emotion/cache": "^10.0.27",
+				"@emotion/css": "^10.0.27",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/sheet": "0.9.4",
+				"@emotion/utils": "0.11.3"
+			}
+		},
+		"@emotion/css": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+			"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+			"requires": {
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/utils": "0.11.3",
+				"babel-plugin-emotion": "^10.0.27"
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+		},
+		"@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+		},
+		"@emotion/serialize": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"requires": {
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/unitless": "0.7.5",
+				"@emotion/utils": "0.11.3",
+				"csstype": "^2.5.7"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "2.6.13",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+					"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+				}
+			}
+		},
+		"@emotion/sheet": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+		},
+		"@emotion/stylis": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+		},
+		"@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+		},
+		"@emotion/utils": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+		},
+		"@emotion/weak-memoize": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+		},
 		"@hapi/address": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -2559,6 +2647,23 @@
 				"object.assign": "^4.1.0"
 			}
 		},
+		"babel-plugin-emotion": {
+			"version": "10.0.33",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+			"integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/serialize": "^0.11.16",
+				"babel-plugin-macros": "^2.0.0",
+				"babel-plugin-syntax-jsx": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7"
+			}
+		},
 		"babel-plugin-istanbul": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -2636,6 +2741,11 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
 			"integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA=="
+		},
+		"babel-plugin-syntax-jsx": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -5828,6 +5938,11 @@
 				"make-dir": "^2.0.0",
 				"pkg-dir": "^3.0.0"
 			}
+		},
+		"find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -10969,6 +11084,14 @@
 				"webpack-dev-server": "3.11.0",
 				"webpack-manifest-plugin": "2.2.0",
 				"workbox-webpack-plugin": "4.3.1"
+			}
+		},
+		"react-spinners": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.9.0.tgz",
+			"integrity": "sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==",
+			"requires": {
+				"@emotion/core": "^10.0.15"
 			}
 		},
 		"react-tooltip": {

--- a/When/ClientApp/package.json
+++ b/When/ClientApp/package.json
@@ -22,6 +22,7 @@
 		"react-router-bootstrap": "^0.25.0",
 		"react-router-dom": "^5.1.2",
 		"react-scripts": "^3.4.1",
+		"react-spinners": "^0.9.0",
 		"react-tooltip": "^4.2.10",
 		"reactstrap": "^8.4.1",
 		"rimraf": "^2.6.2",

--- a/When/ClientApp/src/pages/NewPoll.module.css
+++ b/When/ClientApp/src/pages/NewPoll.module.css
@@ -95,7 +95,8 @@ label {
 		font-size: 16px;
 	}
 
-	#submitButton {
+	#submitButton,
+	#submitSpinner {
 		justify-self: center;
 	}
 }

--- a/When/ClientApp/src/pages/NewPoll.tsx
+++ b/When/ClientApp/src/pages/NewPoll.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ClipLoader from 'react-spinners/ClipLoader';
 import { useHistory } from 'react-router-dom';
 
 import styles from './NewPoll.module.css';
@@ -19,6 +20,8 @@ export const NewPoll = () => {
 	const [authorName, setAuthorName] = useState('');
 	const [pollTitle, setPollTitle] = useState('');
 	const [selectedDays, setSelectedDays] = useState([] as Date[]);
+
+	const [isSubmitLoading, setIsSubmitLoading] = useState(false);
 
 	const [nameEmptyError, setNameEmptyError] = useState(false);
 	const [titleEmptyError, setTitleEmptyError] = useState(false);
@@ -104,8 +107,12 @@ export const NewPoll = () => {
 			body: JSON.stringify(poll),
 		};
 
+		setIsSubmitLoading(true);
+
 		const response = await fetch('api/polls', requestOptions);
 		const data = await response.json();
+
+		setIsSubmitLoading(false);
 
 		const pollId = data.id;
 		showSuccessDialog(pollId);
@@ -153,10 +160,16 @@ export const NewPoll = () => {
 					modifiers={{ all: (day) => true }}
 					modifiersStyles={{ all: { minWidth: '40px', height: '40px' } }}
 				/>
-				<SubmitButton
-					submitHandler={() => postPoll()}
-					id={styles.submitButton}
-				/>
+				{isSubmitLoading ? (
+					<div id={styles.submitSpinner}>
+						<ClipLoader color="#afafaf" size="60" />
+					</div>
+				) : (
+					<SubmitButton
+						submitHandler={() => postPoll()}
+						id={styles.submitButton}
+					/>
+				)}
 			</div>
 		</div>
 	);

--- a/When/ClientApp/src/pages/Poll.module.css
+++ b/When/ClientApp/src/pages/Poll.module.css
@@ -10,10 +10,14 @@
 	column-gap: 16px;
 }
 
-.spinner {
+#pollSpinner {
 	display: flex;
 	justify-content: center;
 	margin: 100px;
+}
+
+#submitSpinner {
+	margin-bottom: 15px;
 }
 
 #participantHeading {

--- a/When/ClientApp/src/pages/Poll.module.css
+++ b/When/ClientApp/src/pages/Poll.module.css
@@ -10,6 +10,12 @@
 	column-gap: 16px;
 }
 
+.spinner {
+	display: flex;
+	justify-content: center;
+	margin: 100px;
+}
+
 #participantHeading {
 	margin: 16px 0;
 	text-align: left;

--- a/When/ClientApp/src/pages/Poll.tsx
+++ b/When/ClientApp/src/pages/Poll.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import ClipLoader from "react-spinners/ClipLoader";
+import ClipLoader from 'react-spinners/ClipLoader';
 import styles from './Poll.module.css';
 
 import { useParams, useHistory } from 'react-router-dom';
@@ -25,6 +25,8 @@ export const Poll = () => {
 	const history = useHistory();
 
 	const [isLoading, setIsLoading] = useState(true);
+	const [isSubmitLoading, setIsSubmitLoading] = useState(false);
+
 	const [pollTitle, setPollTitle] = useState('');
 	const [authorId, setAuthorId] = useState('');
 
@@ -199,6 +201,8 @@ export const Poll = () => {
 
 		await fetch(`api/userSelections`, requestOptions);
 
+		setIsSubmitLoading(false);
+
 		await SwalWReact.fire({
 			icon: 'success',
 			title: `Vielen Dank für Deine Teilnahme, ${username}!`,
@@ -239,6 +243,8 @@ export const Poll = () => {
 		};
 
 		await fetch(`api/userSelections/${id}`, requestOptions);
+
+		setIsSubmitLoading(false);
 
 		await SwalWReact.fire({
 			icon: 'success',
@@ -321,7 +327,11 @@ export const Poll = () => {
 	const pollAuthor = participants.find((p) => p.id === authorId)?.name;
 
 	if (isLoading) {
-		return (<div className={styles.spinner}><ClipLoader color="#afafaf" size="60" /></div>);
+		return (
+			<div id={styles.pollSpinner}>
+				<ClipLoader color="#afafaf" size="60" />
+			</div>
+		);
 	}
 
 	return (
@@ -358,15 +368,24 @@ export const Poll = () => {
 							submitHandler={() => handleEditAction('')}
 						/>
 					)}
-					<SubmitButton
-						submitHandler={() => {
-							if (!idToEdit || idToEdit.trim() === '') {
-								postUserSelection(username, userSelections);
-							} else {
-								putUserSelection(idToEdit, username, userSelections);
-							}
-						}}
-					/>
+
+					{isSubmitLoading ? (
+						<div id={styles.submitSpinner}>
+							<ClipLoader color="#afafaf" size="60" />
+						</div>
+					) : (
+						<SubmitButton
+							submitHandler={() => {
+								setIsSubmitLoading(true);
+
+								if (!idToEdit || idToEdit.trim() === '') {
+									postUserSelection(username, userSelections);
+								} else {
+									putUserSelection(idToEdit, username, userSelections);
+								}
+							}}
+						/>
+					)}
 				</div>
 			</div>
 			<h3 id={styles.participantHeading} className="subtitle">

--- a/When/ClientApp/src/pages/Poll.tsx
+++ b/When/ClientApp/src/pages/Poll.tsx
@@ -264,24 +264,13 @@ export const Poll = () => {
 	};
 
 	const deleteUserSelection = async (id: string) => {
+		setIsLoading(true);
+
 		const requestOptions = {
 			method: 'DELETE',
 		};
 
 		await fetch(`api/userSelections/${id}`, requestOptions);
-
-		await SwalWReact.fire({
-			icon: 'success',
-			title: 'Der Eintrag wurde gelöscht!',
-			html: (
-				<SubmitButton
-					submitHandler={() => {
-						Swal.clickConfirm();
-					}}
-				/>
-			),
-			showConfirmButton: false,
-		});
 
 		handleEditAction('');
 		fetchPollData();

--- a/When/ClientApp/src/pages/Poll.tsx
+++ b/When/ClientApp/src/pages/Poll.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import ClipLoader from "react-spinners/ClipLoader";
 import styles from './Poll.module.css';
 
 import { useParams, useHistory } from 'react-router-dom';
@@ -23,6 +24,7 @@ export const Poll = () => {
 	const { pollId } = useParams();
 	const history = useHistory();
 
+	const [isLoading, setIsLoading] = useState(true);
 	const [pollTitle, setPollTitle] = useState('');
 	const [authorId, setAuthorId] = useState('');
 
@@ -129,6 +131,8 @@ export const Poll = () => {
 	const fetchPollData = useCallback(async () => {
 		const response = await fetch(`api/polls/${pollId}`);
 		const data = await response.json();
+
+		setIsLoading(false);
 
 		if (data.errors || data.status == 404) {
 			history.push('/404');
@@ -315,6 +319,10 @@ export const Poll = () => {
 	/* UI */
 
 	const pollAuthor = participants.find((p) => p.id === authorId)?.name;
+
+	if (isLoading) {
+		return (<div className={styles.spinner}><ClipLoader color="#afafaf" size="60" /></div>);
+	}
 
 	return (
 		<div className="main">

--- a/When/ClientApp/src/pages/Poll.tsx
+++ b/When/ClientApp/src/pages/Poll.tsx
@@ -131,6 +131,8 @@ export const Poll = () => {
 	/* CRUD operations */
 
 	const fetchPollData = useCallback(async () => {
+		setIsLoading(true);
+
 		const response = await fetch(`api/polls/${pollId}`);
 		const data = await response.json();
 
@@ -184,6 +186,8 @@ export const Poll = () => {
 	) => {
 		if (!username || username.trim() === '') {
 			setUsernameEmptyError(true);
+			setIsSubmitLoading(false);
+
 			return;
 		}
 
@@ -226,6 +230,8 @@ export const Poll = () => {
 	) => {
 		if (!username || username.trim() === '') {
 			setUsernameEmptyError(true);
+			setIsSubmitLoading(false);
+
 			return;
 		}
 


### PR DESCRIPTION
Closes #18 

Added some loading spinners to block buttons/the entire UI when a request to the API is ongoing, namely:

- To the Poll page if a poll is being fetched
- To the SubmitButton on the Poll page if a user selection is being submitted
- To the SubmitButton on the Poll page if a user selection is being submitted after an edit
- To the Poll page if a user selection is being deleted
- To the NewPoll page if a new poll is being posted

With this change, the UI should now be blocked during (most) API calls and provide the user with the information that an operation is in progress.