### PR TITLE
Use In-Memory-DB if env variable $DATABASE_URL is not set

### DIFF
--- a/When/Startup.cs
+++ b/When/Startup.cs
@@ -44,9 +44,17 @@ namespace When
         public void ConfigureServices(IServiceCollection services)
         {
             var dbUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
-            
-            services.AddDbContext<PollContext>(opt => 
-                opt.UseNpgsql(ConnectionStringFromDbUrl(dbUrl)));
+
+            if (dbUrl == null)
+            {
+                services.AddDbContext<PollContext>(opt => 
+                    opt.UseInMemoryDatabase("WhenPolls"));
+            }
+            else
+            {
+                services.AddDbContext<PollContext>(opt =>
+                    opt.UseNpgsql(ConnectionStringFromDbUrl(dbUrl)));
+            }
 
             services.AddControllersWithViews().AddNewtonsoftJson(options => 
                 options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore


### PR DESCRIPTION
Right now, you have to have PostgreSQL installed on your local machine in order to run the server, as it expects a running Postgres Server to connect to and have the `$DATABASE_URL` set as an environment variable.

While this is fine for a production environment, and maybe also for testing DB interaction on a local machine, it kind of hinders local prototyping  when interaction with the DB is not quite important (e.g. when prototyping the Frontend). It also kind of makes contributing to the project a bit harder as it imposes installation requirements on contributors.

With this change, the server checks for the `$DATABASE_URL` env variable and if it is not set/present, it simply uses an `InMemoryDatabase` which does not persist data across restarts but is perfectly fine for quickly prototyping different use cases. 