### PR TITLE
Only show hover effect for ToggleButton if there is a pointing device

### DIFF
--- a/When/ClientApp/src/components/ToggleButton.module.css
+++ b/When/ClientApp/src/components/ToggleButton.module.css
@@ -23,10 +23,12 @@
 	box-shadow: none;
 }
 
-.toggleButton.no:hover {
-	border: none;
-	background-color: #129f0077;
-	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+@media (hover: hover) {
+	.toggleButton.no:hover {
+		border: none;
+		background-color: #129f0077;
+		box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+	}
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Closes #28 

By adding a media query to discern whether the current browser has a primary pointing device (i.e. a mouse), we can turn on/off the hover effect for the `ToggleButton`.

Therefore, if we have a mouse pointer on desktop, the hover effect is shown, whereas, if we don't, as in mobile, we can remove the "sticky hover" effect, which appears when you have tapped the `ToggleButton`. 

This should lead to a more clearer UI as there is no light green button anymore when you tapped a `ToggleButton` in the `Maybe` state.