### PR TITLE
Deploy version with .NET 5 SDK

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,24 +2,23 @@ name: .NET Core
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.301
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.102
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/When.sln
+++ b/When.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "When", "When\When.csproj", "{CE3ADFAA-CB8D-48CB-A560-550ACABB45A7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhenTests", "WhenTests\WhenTests.csproj", "{715A70F2-96CA-4C17-B0FE-91CCD655E502}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhenTests", "WhenTests\WhenTests.csproj", "{D96782BD-7446-4FA3-966F-23CA2DBCCB66}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +15,9 @@ Global
 		{CE3ADFAA-CB8D-48CB-A560-550ACABB45A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CE3ADFAA-CB8D-48CB-A560-550ACABB45A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE3ADFAA-CB8D-48CB-A560-550ACABB45A7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{715A70F2-96CA-4C17-B0FE-91CCD655E502}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{715A70F2-96CA-4C17-B0FE-91CCD655E502}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{715A70F2-96CA-4C17-B0FE-91CCD655E502}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{715A70F2-96CA-4C17-B0FE-91CCD655E502}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D96782BD-7446-4FA3-966F-23CA2DBCCB66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D96782BD-7446-4FA3-966F-23CA2DBCCB66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D96782BD-7446-4FA3-966F-23CA2DBCCB66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D96782BD-7446-4FA3-966F-23CA2DBCCB66}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/When/Properties/launchSettings.json
+++ b/When/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,

--- a/When/When.csproj
+++ b/When/When.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
@@ -11,15 +11,15 @@
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'When' " />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WhenTests/WhenTests.csproj
+++ b/WhenTests/WhenTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
In order to support the new SDK version in the Heroku .NET Buildpack, lifted the SDK version up to the .NET 5 SDK, as it is also an important update.